### PR TITLE
Set site to load in light mode by default

### DIFF
--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -23,17 +23,13 @@ interface ThemeProviderProps {
 
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
   const [theme, setTheme] = useState<Theme>(() => {
-    // Check localStorage first, then system preference
+    // Check localStorage first
     const savedTheme = localStorage.getItem('theme') as Theme;
     if (savedTheme) {
       return savedTheme;
     }
     
-    // Check system preference
-    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      return 'dark';
-    }
-    
+    // Default to light mode regardless of system preference
     return 'light';
   });
 


### PR DESCRIPTION
- Updated ThemeContext to default to light mode instead of dark
- Removed system preference check that was forcing dark mode
- Preserved localStorage functionality for user theme preferences
- New visitors will now see the site in light mode by default